### PR TITLE
Optimize multiselectfield to_python method.

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -152,7 +152,8 @@ class MultiSelectField(models.CharField):
             if isinstance(value, list):
                 return value
             elif isinstance(value, string_type):
-                return MSFList(choices, value.split(','))
+                value_list = map(lambda x: x.strip(), value.replace('，', ',').split(','))
+                return MSFList(choices, value_list)
             elif isinstance(value, (set, dict)):
                 return MSFList(choices, list(value))
         return MSFList(choices, [])


### PR DESCRIPTION
When using  with django import export plugin, optimize these 2 things:
1. User usally input a " " after ",",  optimize the parse method, trim it.
2. User also can input "，" instead of ",",  for a better user experience.